### PR TITLE
PZX player: Añadir funcionalidad de marca de usuario y rebobinado.

### DIFF
--- a/cores/spectrum/exp27/common/config.vh
+++ b/cores/spectrum/exp27/common/config.vh
@@ -1,4 +1,4 @@
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 18:39:21 2020-02-09 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -52,16 +52,16 @@
 `define MONOCHROMERGB
 //`define SAA1099
 // ZXUNO core ID string. Must be padded with zero bytes to the right (16 bytes total)
-  localparam COREID_STRING = {"EXP27-220521", 8'h00, 8'h00, 8'h00, 8'h00};
+  localparam COREID_STRING = {"EXP27-130621", 8'h00, 8'h00, 8'h00, 8'h00};
 
-// Power-on/FPGA PROG video configuration  
+// Power-on/FPGA PROG video configuration
   localparam
     VSYNC_OPTION     = 1'b0,   // 0=Sinclair simple vertical sync, 1=proper PAL vsync
     FREQ_OPTION      = 3'b000, // 0 to 7 (50 to almost 60 Hz)
     SCANLINES_OPTION = 1'b0,   // 0=no scanlines, 1=scanlines
     VIDEO_OPTION     = 1'b1;   // 0=RGB, 1=VGA
   localparam INITIAL_VIDEO_VALUE = {2'b00, VSYNC_OPTION, FREQ_OPTION, SCANLINES_OPTION, VIDEO_OPTION};
-  
+
 // ZXUNO address/data I/O ports for indirect access to ZXUNO registers
   localparam
     IOADDR = 16'hFC3B,
@@ -118,7 +118,7 @@
 
 // ZXUNO register for scandoubler/CPU speed options
   localparam SCANDBLCTRL = 8'h0B;
-	
+
 // I/O port	for CPU speed option (Prism compatible)
   localparam PRISMSPEEDCTRL = 16'h8e3b;  // PRISM speed control: bits D3-D0. Bits D7-D4 must be 0000
 

--- a/cores/spectrum/exp27/common/ps2_keyb.v
+++ b/cores/spectrum/exp27/common/ps2_keyb.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 15:18:53 2015-06-03 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -34,8 +34,8 @@ module ps2_keyb(
     output wire rst_out_n,
     output wire nmi_out_n,
     output wire mrst_out_n,
-    output wire [12:0] user_fnt,  // 13 funciones especiales. Usaremos FF, STOP, PREVTRACK, PLAY, F1 F3 F4 F6 F7 F8 F9 F11 y F12
-    output wire video_output_change,    
+    output wire [13:0] user_fnt,  // 14 funciones especiales. Usaremos FF, STOP, PREVTRACK, PLAY, F1 F3 F4 F6 F7 F8 F9 F11 F12 y CTRL-F8
+    output wire video_output_change,
     //---------------------------------
     input wire [7:0] zxuno_addr,
     input wire zxuno_regrd,
@@ -57,7 +57,7 @@ module ps2_keyb(
     assign mrst_out_n = ~master_reset;
     assign rst_out_n = ~user_reset;
     assign nmi_out_n = ~user_nmi;
-    
+
     assign oe_keymap = (zxuno_addr == KEYMAP && zxuno_regrd == 1'b1);
     assign oe_scancode = (zxuno_addr == SCANCODE && zxuno_regrd == 1'b1);
     assign oe_kbstatus = (zxuno_addr == KBSTATUS && zxuno_regrd == 1'b1);
@@ -70,8 +70,8 @@ module ps2_keyb(
     wire extended;
     wire released;
     wire shift_pressed, ctrl_pressed, alt_pressed;
-    assign scancode_dout = kbcode;    
-    
+    assign scancode_dout = kbcode;
+
     /*
     | BSY | x | x | x | ERR | RLS | EXT | PEN |
     */
@@ -87,7 +87,7 @@ module ps2_keyb(
           kbstatus_dout[0] <= 1'b0;
           reading_kbstatus <= 1'b0;
       end
-    end        
+    end
 
     ps2_port lectura_de_teclado (
         .clk(clk),
@@ -122,9 +122,9 @@ module ps2_keyb(
         .user_nmi(user_nmi),
         .user_fnt(user_fnt),
 		  .monochrome_switcher(monochrome_switcher)
-		  
+
     );
-    
+
     keyboard_pressed_status teclado_limpio (
         .clk(clk),
         .rst(1'b0),

--- a/cores/spectrum/exp27/common/pzx_player.v
+++ b/cores/spectrum/exp27/common/pzx_player.v
@@ -39,7 +39,7 @@ module pzx_player (
     input wire [1:0] cpu_speed,
     input wire [1:0] memory_register,
     input wire play_in,
-//    input wire stop_in,
+    input wire stop_in,
 	input wire rewindTo0Counter_in,
 	input wire resetTo0Counter_in,
     input wire jump_in,
@@ -136,18 +136,18 @@ module pzx_player (
     wire soft_stop_in = vdeckprev[1] & ~vdeckctrl[1];
 
     reg [1:0] edplay = 2'b00;
-//    reg [1:0] edstop = 2'b00;
+    reg [1:0] edstop = 2'b00;
     reg [1:0] edjump = 2'b00;
     reg [1:0] edrewind = 2'b00;
     reg [1:0] edresetcounter0 = 2'b00;
     wire play = (edplay == 2'b01) | soft_play_in;
-    wire stop = /*(edstop == 2'b01) |*/ soft_stop_in;
+    wire stop = (edstop == 2'b01) | soft_stop_in;
     wire jump = (edjump == 2'b01);
     wire rewindTo0Counter = (edrewind == 2'b01);
     wire resetTo0Counter = (edresetcounter0 == 2'b01);
     always @(posedge clk) begin
       edplay <= {edplay[0], play_in};
-//      edstop <= {edstop[0], stop_in};
+      edstop <= {edstop[0], stop_in};
       edjump <= {edjump[0], jump_in};
       edrewind <= {edrewind[0], rewindTo0Counter_in};
       edresetcounter0 <= {edresetcounter0[0], resetTo0Counter_in};

--- a/cores/spectrum/exp27/common/scancode_to_speccy.v
+++ b/cores/spectrum/exp27/common/scancode_to_speccy.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 17:42:40 2015-06-01 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -43,9 +43,9 @@ module scancode_to_speccy (
     input wire cpuwrite,
     input wire cpuread,
     input wire rewind
-	 
+
     );
-    
+
     // las 40 teclas del Spectrum. Se inicializan a "no pulsadas".
     reg [4:0] row[0:7];
     initial begin
@@ -58,7 +58,7 @@ module scancode_to_speccy (
         row[6] = 5'b11111;
         row[7] = 5'b11111;
     end
-        
+
     // El gran mapa de teclado y sus registros de acceso
     reg [7:0] keymap1[0:2047];  // 2K x 8 bits
     reg [7:0] keymap2[0:2047];  // 2K x 8 bits
@@ -68,13 +68,13 @@ module scancode_to_speccy (
         $readmemh ("../keymaps/keyb1_es_hex.txt", keymap1);
         $readmemh ("../keymaps/keyb2_es_hex.txt", keymap2);
     end
-    
+
     reg [2:0] keyrow1 = 3'h0;
     reg [4:0] keycol1 = 5'h00;
     reg [2:0] keyrow2 = 3'h0;
     reg [4:0] keycol2 = 5'h00;
     reg [2:0] signalstate = 3'b000;
-    
+
     // Asi funciona la matriz de teclado cuando se piden semifilas
     // desde la CPU.
 		integer r;
@@ -85,22 +85,22 @@ module scancode_to_speccy (
 	  		  sp_col = sp_col & row[r];
 			end
 		end
-                    
-    parameter 
-        CLEANMATRIX     = 4'd0, 
-        IDLE            = 4'd1, 
-        READSPKEY       = 4'd2, 
+
+    parameter
+        CLEANMATRIX     = 4'd0,
+        IDLE            = 4'd1,
+        READSPKEY       = 4'd2,
         TRANSLATE1      = 4'd3,
         TRANSLATE2      = 4'd4,
         CPUTIME         = 4'd5,
         CPUREAD         = 4'd6,
         CPUWRITE        = 4'd7,
         CPUINCADD       = 4'd8;
-        
+
     reg [3:0] state = CLEANMATRIX;
     reg key_is_pending = 1'b0;
     wire [2:0] modifiers = {alt_pressed, ctrl_pressed, shift_pressed};
-    
+
     always @(posedge clk) begin
       if (scan_received == 1'b1)
           key_is_pending <= 1'b1;
@@ -138,7 +138,7 @@ module scancode_to_speccy (
               end
               TRANSLATE1: begin
                   // Actualiza las 8 semifilas del teclado con la primera tecla
-                  if (~released) begin            
+                  if (~released) begin
                     row[keyrow1] <= row[keyrow1] & ~keycol1;
                   end
                   else begin
@@ -148,7 +148,7 @@ module scancode_to_speccy (
               end
               TRANSLATE2: begin
                   // Actualiza las 8 semifilas del teclado con la segunda tecla
-                  if (~released) begin            
+                  if (~released) begin
                     row[keyrow2] <= row[keyrow2] & ~keycol2;
                   end
                   else begin
@@ -156,7 +156,7 @@ module scancode_to_speccy (
                   end
                   state <= IDLE;
               end
-              CPUTIME: begin            
+              CPUTIME: begin
                   if (rewind == 1'b1) begin
                       cpuaddr <= 12'h0000;
                       state <= IDLE;
@@ -198,7 +198,7 @@ module scancode_to_speccy (
           endcase
       end
     end
-endmodule	
+endmodule
 
 module keyboard_pressed_status (
     input wire clk,
@@ -209,17 +209,17 @@ module keyboard_pressed_status (
     input wire released,
     output reg kbclean
     );
-    
+
     reg [255:0] keybstat;  // keymap
     initial begin
       kbclean = 1'b1;
       keybstat = 256'h0;
     end
-    
+
 		always @(posedge clk)
       kbclean <= ~(|keybstat);
-		
-    always @(posedge clk) begin		    
+
+    always @(posedge clk) begin
       if (rst == 1'b1)
         keybstat <= 256'h0;
       else if (scan_received == 1'b1)
@@ -246,10 +246,10 @@ module kb_special_functions (
   output reg joyright,
   output reg joyfire,
   output reg video_output_change,
-  output reg [12:0] user_fnt,
+  output reg [13:0] user_fnt,
   output reg [1:0] monochrome_switcher
   );
-  
+
   parameter
     LEFT_SHIFT  = 9'h012,
     RIGHT_SHIFT = 9'h059,
@@ -288,7 +288,7 @@ module kb_special_functions (
     FF          = 9'h130,
 	 END			 = 9'h169
     ;
-  
+
   initial begin
     master_reset = 1'b0;
     user_reset = 1'b0;
@@ -299,14 +299,14 @@ module kb_special_functions (
     joyright = 1'b0;
     joyfire = 1'b0;
     video_output_change = 1'b0;
-    user_fnt = 9'h000;
+    user_fnt = 14'h0000;
     shift_pressed = 1'b0;
     ctrl_pressed = 1'b0;
     alt_pressed = 1'b0;
-	 monochrome_switcher = 2'b0;	 
-	 
+	 monochrome_switcher = 2'b0;
+
   end
-  
+
   always @(posedge clk) begin
     if (rst == 1'b1) begin
       user_nmi <= 1'b0;
@@ -316,7 +316,7 @@ module kb_special_functions (
       joyright <= 1'b0;
       joyfire <= 1'b0;
       video_output_change <= 1'b0;
-      user_fnt <= 13'h0000;
+      user_fnt <= 14'h0000;
       shift_pressed <= 1'b0;
       ctrl_pressed <= 1'b0;
       alt_pressed <= 1'b0;
@@ -324,18 +324,18 @@ module kb_special_functions (
     else begin
       if (video_output_change == 1'b1)
         video_output_change <= 1'b0;
-		 
+
       if (scan_received == 1'b1) begin
 		  if (released == 1'b1) begin
-									
+
 				case ({extended, scancode})
 				  END						  : monochrome_switcher <= monochrome_switcher + 1; // MonochromeRGB
 				  F11                   : user_fnt[1] <= ~user_fnt[1]; // WiFi ON/OFF
 				  F12                   : user_fnt[0] <= ~user_fnt[0]; // Turbo-boost ON/OFF
 				endcase
-				
+
 		  end
-		  
+
         case ({extended, scancode})
           LEFT_SHIFT,RIGHT_SHIFT: shift_pressed <= ~released;
           LEFT_CTRL,RIGHT_CTRL  : ctrl_pressed <= ~released;
@@ -373,22 +373,25 @@ module kb_special_functions (
                                     joydown <= ~released;
                                     joyright <= ~released;
                                   end
-          F1                    : user_fnt[8] <= ~released;			 
+          F1                    : user_fnt[8] <= ~released;
           F3                    : user_fnt[7] <= ~released;
           F4                    : user_fnt[6] <= ~released;
           F6                    : user_fnt[5] <= ~released;
           F7                    : user_fnt[4] <= ~released;
-          F8                    : user_fnt[3] <= ~released;
+          F8                    : begin
+                                      if (ctrl_pressed) user_fnt[13] <= (~released);
+                                      else user_fnt[3] <= (~released);
+                                  end
           F9                    : user_fnt[2] <= ~released;
-          //F11                   : user_fnt[1] <= ~released;			 
+          //F11                   : user_fnt[1] <= ~released;
           //F12                   : user_fnt[0] <= ~released;
           PLAY                  : user_fnt[9] <= ~released;
           PREVTRACK             : user_fnt[10] <= ~released;
           STOP                  : user_fnt[11] <= ~released;
-          FF                    : user_fnt[12] <= ~released;			 
+          FF                    : user_fnt[12] <= ~released;
           // 12 funciones especiales. Usaremos FF, STOP, PREVTRACK, PLAY, F1 F3 F4 F6 F7 F8 F9 F11 y F12
         endcase
       end
     end
-  end    
+  end
 endmodule

--- a/cores/spectrum/exp27/common/zxuno.v
+++ b/cores/spectrum/exp27/common/zxuno.v
@@ -174,7 +174,7 @@ module zxuno (
   wire [7:0]  kbstatus_dout;
   wire        oe_kbstatus;
 
-  wire [12:0] user_fnt;
+  wire [13:0] user_fnt;
   wire ff_pressed        = user_fnt[12];
   wire stop_pressed      = user_fnt[11];
   wire prevtrack_pressed = user_fnt[10];
@@ -184,8 +184,9 @@ module zxuno (
   wire f4_pressed        = user_fnt[6];
   wire f6_pressed        = user_fnt[5];   // Establecer marca de 'contador a 0'
   wire f7_pressed        = user_fnt[4];   // PLAY del PZX
-  wire f8_pressed        = user_fnt[3];   // REWIND al principio del PZX, o a la última posición marcada en el fichero
-  wire f9_pressed        = user_fnt[2];   // REWIND a la marca del 'contador a 0' puesta por usuario con F6
+  wire f8_pressed        = user_fnt[3];   // REWIND a la marca del 'contador a 0' puesta por usuario con F6
+  wire f8_ctrl_pressed   = user_fnt[13];   // REWIND al principio del PZX, o a la última posición marcada en el fichero
+  wire f9_pressed        = user_fnt[2];   // STOP del PZX
   wire f11_pressed       = user_fnt[1];   // WiFi
   wire f12_pressed       = user_fnt[0];   // Turbo-boost (28 MHz)
 
@@ -290,10 +291,10 @@ module zxuno (
   wire pzx_output;
   wire in48kmode;
   wire play = play_pressed | f7_pressed;
-//  wire stop = stop_pressed | f9_pressed;
-  wire rewindTo0Counter = f9_pressed;
+  wire stop = stop_pressed | f9_pressed;
+  wire rewindTo0Counter = f8_pressed;
   wire resetTo0Counter = f6_pressed;
-  wire jump = prevtrack_pressed | f8_pressed;
+  wire jump = prevtrack_pressed | f8_ctrl_pressed;
   wire [7:0] data_from_pzx;
   wire [7:0] data_to_pzx;
   wire write_data_pzx;
@@ -805,7 +806,7 @@ module zxuno (
     .cpu_speed(cpu_speed),
     .memory_register(total_memory),
     .play_in(play),
-//    .stop_in(stop),
+    .stop_in(stop),
     .rewindTo0Counter_in(rewindTo0Counter),
     .resetTo0Counter_in(resetTo0Counter),
     .jump_in(jump),

--- a/cores/spectrum/exp27/common/zxuno.v
+++ b/cores/spectrum/exp27/common/zxuno.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 14:16:16 2014-02-06 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -28,7 +28,7 @@ module zxuno (
   // Relojes
   input wire sysclk,
   input wire power_on_reset_n,
-  
+
   // E/S
   output wire [2:0] r,
   output wire [2:0] g,
@@ -43,18 +43,18 @@ module zxuno (
   input wire ear_ext,
   output wire audio_out_left,
   output wire audio_out_right,
-  
+
   // MIDI
   output wire midi_out,
   input wire clkbd,
   input wire wsbd,
-  input wire dabd,    
-  
+  input wire dabd,
+
   // UART
   output wire uart_tx,
   input wire uart_rx,
   output wire uart_rts,
-  
+
   // SRAM
   output wire [20:0] sram_addr,
   inout wire [7:0] sram_data,
@@ -65,38 +65,38 @@ module zxuno (
   output wire flash_clk,
   output wire flash_di,
   input wire flash_do,
-  
+
   // SD/MMC
-  output wire sd_cs_n,    
-  output wire sd_clk,     
-  output wire sd_mosi,    
+  output wire sd_cs_n,
+  output wire sd_clk,
+  output wire sd_mosi,
   input wire sd_miso,
-  
+
   // DB9 JOYSTICK
   input wire joy1up,
   input wire joy1down,
   input wire joy1left,
   input wire joy1right,
   input wire joy1fire1,
-  input wire joy1fire2,   
-	 
+  input wire joy1fire2,
+
   input wire joy2up,
   input wire joy2down,
   input wire joy2left,
   input wire joy2right,
   input wire joy2fire1,
-  input wire joy2fire2,   
+  input wire joy2fire2,
 
   // MOUSE
   inout wire mouseclk,
   inout wire mousedata,
-  
+
   // SCANDOUBLER CTRL
   output wire clk14en_tovga,
   output wire vga_enable,
   output wire scanlines_enable,
   output wire [2:0] freq_option,
-  
+
   // AD724
   output wire ad724_xtal,
   output wire ad724_mode,
@@ -130,11 +130,11 @@ module zxuno (
   // Señales acceso RAM por parte de la CPU
   wire [7:0] memory_dout;
   wire oe_romyram;
-  
+
   // Señales de acceso del AY por parte de la CPU
   wire [7:0] ay_dout;
   wire bc1,bdir;
-  wire oe_ay;   
+  wire oe_ay;
 
   // Señales de acceso a registro de direcciones ZX-Uno
   wire [7:0] zxuno_addr_to_cpu;  // al bus de datos de entrada del Z80
@@ -162,7 +162,7 @@ module zxuno (
   wire [7:0] mixer_dout;
   wire oe_mixer;
   wire [ 7:0] saa_out_l, saa_out_r;
-  
+
   // Interfaz de acceso al teclado
   wire [4:0]  kbdcol;
   wire [7:0]  kbdrow = cpuaddr[15:8];                    // las filas del teclado son A8-A15 de la CPU;
@@ -173,7 +173,7 @@ module zxuno (
   wire        oe_keymap;
   wire [7:0]  kbstatus_dout;
   wire        oe_kbstatus;
-  
+
   wire [12:0] user_fnt;
   wire ff_pressed        = user_fnt[12];
   wire stop_pressed      = user_fnt[11];
@@ -182,19 +182,19 @@ module zxuno (
   wire f1_pressed        = user_fnt[8];
   wire f3_pressed        = user_fnt[7];
   wire f4_pressed        = user_fnt[6];
-  wire f6_pressed        = user_fnt[5];
+  wire f6_pressed        = user_fnt[5];   // Establecer marca de 'contador a 0'
   wire f7_pressed        = user_fnt[4];   // PLAY del PZX
   wire f8_pressed        = user_fnt[3];   // REWIND al principio del PZX, o a la última posición marcada en el fichero
-  wire f9_pressed        = user_fnt[2];   // STOP del PZX
+  wire f9_pressed        = user_fnt[2];   // REWIND a la marca del 'contador a 0' puesta por usuario con F6
   wire f11_pressed       = user_fnt[1];   // WiFi
-  wire f12_pressed       = user_fnt[0];   // Turbo-boost (28 MHz)  
-  
+  wire f12_pressed       = user_fnt[0];   // Turbo-boost (28 MHz)
+
   // Interfaz joystick configurable
   wire oe_joystick;
   wire [4:0] kbd_joy;
-  wire [7:0] joystick_dout;   
+  wire [7:0] joystick_dout;
   wire [4:0] kbdcol_to_ula;
-  
+
   // Configuración ULA
   wire [1:0] timing_mode;
   wire issue2_keyboard;
@@ -210,7 +210,7 @@ module zxuno (
   // Scratch register
   wire 	     oe_scratch;
   wire [7:0] scratch_dout;
-  
+
   // AD724 control
   wire oe_ad724;
   wire [7:0] ad724_dout;
@@ -219,11 +219,11 @@ module zxuno (
   wire oe_memrep;
   wire [7:0] memrep_dout;
   wire [1:0] total_memory;
-  
+
   // Multiboot
   wire oe_multiboot;
   wire [7:0] multiboot_dout;
-  
+
   // Scandoubler control
   wire csync_option;
   wire [7:0] scndblctrl_dout;
@@ -231,7 +231,7 @@ module zxuno (
   wire speed_change_allowed;
   wire turbo_boost = ff_pressed | f12_pressed;
   wire video_output_change;
-  
+
   // Raster INT control
   wire rasterint_enable;
   wire vretraceint_disable;
@@ -256,23 +256,23 @@ module zxuno (
   wire disable_mixer;
   wire [7:0] devoptions_dout;
   wire oe_devoptions;
- 
+
   // NMI events
   wire [7:0] nmievents_dout;
   wire oe_nmievents;
   wire nmispecial_n;
   wire page_configrom_active;
-  
+
   // Kempston mouse
   wire [7:0] kmouse_dout;
   wire [7:0] mousedata_dout;
   wire [7:0] mousestatus_dout;
   wire oe_kmouse, oe_mousedata, oe_mousestatus;
-  
+
   // DMA device interface
   wire [7:0] dma_dout;
   wire oe_dma;
-  
+
   // UART
   wire [7:0] uart_dout;
   wire oe_uart;
@@ -280,7 +280,7 @@ module zxuno (
   // Disk drive
   wire [7:0] diskdrive_dout;
   wire oe_diskdrive;
-  
+
   // Lector PZX
   wire [20:0] pzx_addr;
   wire [7:0] pzx_dout;
@@ -290,23 +290,25 @@ module zxuno (
   wire pzx_output;
   wire in48kmode;
   wire play = play_pressed | f7_pressed;
-  wire stop = stop_pressed | f9_pressed;
+//  wire stop = stop_pressed | f9_pressed;
+  wire rewindTo0Counter = f9_pressed;
+  wire resetTo0Counter = f6_pressed;
   wire jump = prevtrack_pressed | f8_pressed;
   wire [7:0] data_from_pzx;
   wire [7:0] data_to_pzx;
   wire write_data_pzx;
   wire ear = (pzx_playing == 1'b1)? pzx_output : ear_ext;
-  
+
   // Inyección de 0xFF directo al bus de datos cuando hay un acuse de recibo de interrupción
   wire oe_intack = (iorq_n == 1'b0 && m1_n == 1'b0);
-  
+
   // Salidas de video de la ULA
   wire [2:0] rula,gula,bula;
   wire [8:0] hcnt, vcnt;
 
   // Señales a conectar valores de depuracion
   wire [15:0] v16_a, v16_b, v16_c, v16_d, v16_e, v16_f, v16_g, v16_h;
-  wire [7:0] v8_a, v8_b, v8_c, v8_d, v8_e, v8_f, v8_g, v8_h; 
+  wire [7:0] v8_a, v8_b, v8_c, v8_d, v8_e, v8_f, v8_g, v8_h;
 
   // Asignación de dato para la CPU segun la decodificación de todos los dispositivos
   // conectados a ella.
@@ -340,7 +342,7 @@ module zxuno (
       oe_joystick    : cpudin = joystick_dout;
       default        : cpudin = ula_dout;  // must always be the last "default" option.
     endcase
-  end        
+  end
 
   clk_enables enables_de_todos_los_relojes (
     .clk                (sysclk         ),
@@ -417,7 +419,7 @@ module zxuno (
     .zxuno_regrd        (zxuno_regrd    ),
     .zxuno_regwr        (zxuno_regwr    ),
     .regaddr_changed    (regaddr_changed),
-  
+
 // I/O ports
     .ear                (ear            ),
     .mic                (mic            ),
@@ -434,8 +436,8 @@ module zxuno (
     .disable_radas      (disable_radas  ),
     .csync_option       (csync_option   ),
 
-  // Debug	  
-//     .button_up(f4_pressed), 
+  // Debug
+//     .button_up(f4_pressed),
 //     .button_down(f3_pressed),
 //     .posint(v8_a),
 
@@ -495,7 +497,7 @@ module zxuno (
     .clk(sysclk),   // Reloj para registros de configuración
     .mrst_n(mrst_n & power_on_reset_n),
     .rst_n(rst_n & power_on_reset_n),
-  
+
 // Interface con la CPU
     .a                  (cpuaddr        ),
     .din                (cpudout        ),                      // proveniente del bus de datos de salida de la CPU
@@ -701,7 +703,7 @@ module zxuno (
     .vretraceint_disable(vretraceint_disable),
     .raster_line        (raster_line    ),
     .raster_int_in_progress(raster_int_in_progress));
-`endif  
+`endif
 
   // DESHABILITADO!!!!!!!!!!!!!!!!!!!!!!!!!
 //    nmievents nmi_especial_de_antonio (
@@ -726,7 +728,7 @@ module zxuno (
   ps2_mouse_kempston el_raton (
     .clk(sysclk),
     .rst_n(rst_n & mrst_n & power_on_reset_n),
- 
+
     .clkps2             (mouseclk       ),
     .dataps2            (mousedata      ),
   //---------------------------------
@@ -744,7 +746,7 @@ module zxuno (
     .oe_mousedata       (oe_mousedata   ),
     .mousestatus_dout   (mousestatus_dout),
     .oe_mousestatus     (oe_mousestatus ));
-  
+
 
 `ifdef MULTIBOOT_SUPPORT
   multiboot el_multiboot (
@@ -773,7 +775,7 @@ module zxuno (
     .specdrum_out       (specdrum       ));
 
 `endif
-  
+
   disk_drive el_disco (
     .clk(sysclk),
     .rst_n(rst_n & mrst_n & power_on_reset_n),
@@ -803,7 +805,9 @@ module zxuno (
     .cpu_speed(cpu_speed),
     .memory_register(total_memory),
     .play_in(play),
-    .stop_in(stop),
+//    .stop_in(stop),
+    .rewindTo0Counter_in(rewindTo0Counter),
+    .resetTo0Counter_in(resetTo0Counter),
     .jump_in(jump),
     .pulse_out(pzx_output),
     .playing(pzx_playing),
@@ -840,9 +844,9 @@ module zxuno (
   //   1   1   1  address
 
   assign bdir = (cpuaddr[15] && cpuaddr[1:0]==2'b01 && !iorq_n && !wr_n)? 1'b1 : 1'b0;
-  assign bc1 = (cpuaddr[15] && cpuaddr[1:0]==2'b01 && cpuaddr[14] && !iorq_n)? 1'b1 : 1'b0;                                                              
+  assign bc1 = (cpuaddr[15] && cpuaddr[1:0]==2'b01 && cpuaddr[14] && !iorq_n)? 1'b1 : 1'b0;
 
-  turbosound dos_ays (     
+  turbosound dos_ays (
     .clk(sysclk),
     .clk35en(clk35en),
     .clk175en(clk175en),
@@ -863,7 +867,7 @@ module zxuno (
 ///////////////////////////////////
 // SOUND SAA1099
 ///////////////////////////////////
-`ifdef SAA1099	
+`ifdef SAA1099
     saa1099s el_saa (
     .clk_sys            (sysclk         ),               // 8 MHz
     .ce                 (clk7en         ),               // 8 MHz
@@ -875,7 +879,7 @@ module zxuno (
     .out_l              (saa_out_l      ),
     .out_r              (saa_out_r      ));
 `endif
-  
+
 ///////////////////////////////////
 // SOUND MIXERS
 ///////////////////////////////////
@@ -906,7 +910,7 @@ module zxuno (
     .midi_right         (midi_right     ),
     .saa_left           (saa_out_l      ),
     .saa_right          (saa_out_r      ),
-  
+
 // PWM output mixed
     .output_left        (audio_out_left ),
     .output_right       (audio_out_right));
@@ -920,7 +924,7 @@ module zxuno (
     .sd(dabd),
     .left_out(midi_left),
     .right_out(midi_right)
-  );  
+  );
 `endif
 
 `ifdef UART_ESP8266_OPTION
@@ -939,9 +943,9 @@ module zxuno (
     .uart_rts           (uart_rts       ));
 `else
   assign uart_tx = 1'b0;
-  assign uart_rts = 1'b0;  
+  assign uart_rts = 1'b0;
 `endif
-  
+
   // Modulo de depuracion
 //  debug visor_valores_en_pantalla (
 //    .clk(sysclk),


### PR DESCRIPTION
Se añade funcionalidad al reproductor PZX para establecer una marca y rebobinar a ella en cualquier momento.

Pulsando F6 se pone la marca de usuario en la posición actual.
F7 es PLAY/PAUSE
F8 rebobina el PZX a la marca de usuario.
Ctrl-F8 rebobina el PZX a la marca de fichero.
F9 es STOP.