### PR TITLE
Joystick splitter support

### DIFF
--- a/cores/spectrum/exp27/common/config.vh
+++ b/cores/spectrum/exp27/common/config.vh
@@ -46,6 +46,7 @@
 `define SPECDRUM_COVOX_SUPPORT
 `define MULTIBOOT_SUPPORT
 //`define PENTAGON_512K_SUPPORT
+//`define JOYSPLITTER_SUPPORT
 
 // FPGA color clock generation needs AD724 control support enabled
 //`define AD724_CONTROL_SUPPORT
@@ -53,7 +54,7 @@
 `define MONOCHROMERGB
 //`define SAA1099
 // ZXUNO core ID string. Must be padded with zero bytes to the right (16 bytes total)
-  localparam COREID_STRING = {"EXP27-130621", 8'h00, 8'h00, 8'h00, 8'h00};
+  localparam COREID_STRING = {"EXP27-071021", 8'h00, 8'h00, 8'h00, 8'h00};
 
 // Power-on/FPGA PROG video configuration
   localparam
@@ -86,7 +87,7 @@
 // ZXUNO registers for SPI devices (flash)
   localparam
       SPIPORT = 8'h02,     // registro de lectura/escritura SPI
-      CSPIN   = 8'h03;     // bit 0: estado/control de la señal FLASH_CS
+      CSPIN   = 8'h03;     // bit 0: estado/control de la seÃ±al FLASH_CS
 
 // ZXUNO registers for PS/2 keyboard handling
   localparam
@@ -107,7 +108,8 @@
 
 // I/O ports for Kempston and Fuller joystick interfaces
   localparam
-   KEMPSTONADDR    = 8'h1F,
+   KEMPSTONADDR1    = 8'h1F,
+   KEMPSTONADDR2    = 8'hDF,
    FULLERADDR      = 8'h7F;
 
 // I/O ports for SD card (ZXMMC and DIVMMC)

--- a/cores/spectrum/exp27/common/joystick_protocols.v
+++ b/cores/spectrum/exp27/common/joystick_protocols.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 15:52:26 2015-06-07 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -40,6 +40,7 @@ module joystick_protocols (
     input wire [4:0] kbdjoy_in,
     input wire [5:0] db9joy1_in,
     input wire [5:0] db9joy2_in,
+    output wire joy1fire3,
     input wire [4:0] kbdcol_in,
     output reg [4:0] kbdcol_out,
     input wire vertical_retrace_int_n // this is used as base clock for autofire
@@ -50,7 +51,7 @@ module joystick_protocols (
     localparam
       SINCLAIRP1ADDR  = 12,
       SINCLAIRP2ADDR  = 11,
-      SINCLAIRADDRE 	= 8, 	//sinclair extendido, semifila ZXCV	  
+      SINCLAIRADDRE 	= 8, 	//sinclair extendido, semifila ZXCV
       DISABLED        = 3'h0,
       KEMPSTON        = 3'h1,
       SINCLAIRP1      = 3'h2,
@@ -58,11 +59,40 @@ module joystick_protocols (
       CURSOR          = 3'h4,
       FULLER          = 3'h5,
       // Protocolo OPQASPACEM
-  		KMAPOPQA        = 3'h6,		  
+  		KMAPOPQA        = 3'h6,
       KMAPOP		      = 13,
       KMAPQ			      = 10,
       KMAPA			      = 9,
-      KMAPSPACEM	    = 15;	  
+      KMAPSPACEM	    = 15;
+
+`ifdef JOYSPLITTER_SUPPORT
+
+    // Joystick multiplex (hardware joystick splitter)
+
+    reg joySelector = 1'b0;
+    assign joy1fire3 = joySelector;
+    reg [5:0] db9joy1_muxed = 6'b111111;
+    reg [5:0] db9joy2_muxed = 6'b111111;
+    reg [18:0] joyMuxerCounter = 19'd0;
+    always @(posedge clk) begin
+        if ( joyMuxerCounter == 19'd0 ) begin
+            // 28 MHz / 140000 = 200 Hz, 100 Hz for each joystick.
+            joyMuxerCounter <= 19'd140000;
+            if ((joyconf[7] == 1'b0) || (joySelector == 1'b0)) begin
+                db9joy1_muxed <= db9joy1_in;
+            end
+            else begin
+                db9joy2_muxed <= db9joy1_in;
+            end
+            joySelector <= ~joySelector;
+        end
+        else begin
+            joyMuxerCounter <= joyMuxerCounter - 19'd1;
+        end
+    end
+`else
+    assign joy1fire3 = 1'b0;
+`endif
 
     // Input format: FUDLR . 0=pressed, 1=released
     reg db9joyup;
@@ -77,18 +107,27 @@ module joystick_protocols (
     reg kbdjoyright;
     reg kbdjoyfire1;
     reg kbdjoyfire2;
+
+
+`ifdef JOYSPLITTER_SUPPORT
+    always @* begin
+        {db9joyfire2,db9joyfire1,db9joyup,db9joydown,db9joyleft,db9joyright} <= ~db9joy1_muxed;
+        {kbdjoyfire2,kbdjoyfire1,kbdjoyup,kbdjoydown,kbdjoyleft,kbdjoyright} <= {1'b0, kbdjoy_in} | ~db9joy2_muxed | ~db9joy2_in;
+    end
+`else
     always @* begin
         {db9joyfire2,db9joyfire1,db9joyup,db9joydown,db9joyleft,db9joyright} <= ~db9joy1_in;
         {kbdjoyfire2,kbdjoyfire1,kbdjoyup,kbdjoydown,kbdjoyleft,kbdjoyright} <= {1'b0, kbdjoy_in} | ~db9joy2_in;
     end
-    
+`endif
+
     // Update JOYCONF from CPU
     reg [7:0] joyconf = {1'b0,SINCLAIRP1, 1'b0,KEMPSTON};
     always @(posedge clk) begin
         if (zxuno_addr==JOYCONFADDR && zxuno_regwr==1'b1)
             joyconf <= din;
     end
-    
+
     // Autofire stuff
     reg [2:0] cont_autofire = 3'b000;
     reg edge_detect = 1'b0;
@@ -97,20 +136,27 @@ module joystick_protocols (
       edge_detect <= vertical_retrace_int_n;
       if ({edge_detect,vertical_retrace_int_n} == 2'b01)
           cont_autofire <= cont_autofire + 3'd1;  // count only on raising edge of vertical retrace int
-    end    
+    end
     wire kbdjoyfire_processed = (joyconf[3]==1'b0)? kbdjoyfire1 : kbdjoyfire1 & autofire;
+
+    // Config bit joyconf[7] is db9 joystick autofire enable. Except if splitter supported, where it is 'splitter enabled' bit.
+	// In that case joyconf[3] is autofire enable for both joysticks.
+`ifdef JOYSPLITTER_SUPPORT
+    wire db9joyfire_processed = (joyconf[3]==1'b0)? db9joyfire1 : db9joyfire1 & autofire;
+`else
     wire db9joyfire_processed = (joyconf[7]==1'b0)? db9joyfire1 : db9joyfire1 & autofire;
-    
+`endif
+
     always @* begin
       oe = 1'b0;
       dout = 8'hFF;
       kbdcol_out = kbdcol_in;
-      if (zxuno_addr==JOYCONFADDR && zxuno_regrd==1'b1) begin  // lectura específica de I/O de ZXUNO
+      if (zxuno_addr==JOYCONFADDR && zxuno_regrd==1'b1) begin  // lectura especÃ­fica de I/O de ZXUNO
         oe = 1'b1;
         dout = joyconf;
       end
-      else if (iorq_n == 1'b0 && rd_n == 1'b0) begin  // lectura genérica de I/O
-        if (a[7:0] == KEMPSTONADDR) begin
+      else if (iorq_n == 1'b0 && rd_n == 1'b0) begin  // lectura genÃ©rica de I/O
+        if ((a[7:0] == KEMPSTONADDR1) || (a[7:0] == KEMPSTONADDR2)) begin
           dout = 8'h00;
           oe = 1'b1;
           if (joyconf[2:0] == KEMPSTON) begin
@@ -118,6 +164,9 @@ module joystick_protocols (
           end
           if (joyconf[6:4] == KEMPSTON) begin
               dout = dout | {2'b00, db9joyfire2, db9joyfire_processed, db9joyup, db9joydown, db9joyleft, db9joyright};
+          end
+          if ((joyconf[2:0] != KEMPSTON) && (joyconf[6:4] != KEMPSTON)) begin
+            dout = 8'hFF;
           end
         end
         else if (a[7:0] == FULLERADDR) begin
@@ -137,7 +186,7 @@ module joystick_protocols (
             if (joyconf[6:4]==SINCLAIRP1)
                 kbdcol_out = kbdcol_out & {~db9joyleft,~db9joyright,~db9joydown,~db9joyup,~db9joyfire_processed};
             if (joyconf[2:0]==CURSOR)
-                kbdcol_out = kbdcol_out & {~kbdjoydown,~kbdjoyup,~kbdjoyright,1'b1,~kbdjoyfire_processed};
+                kbdcol_out = kbdcol_out & {~kbdjoydown,~kbdjoyup,~kbdjoyright,~kbdjoyfire2,~kbdjoyfire_processed};
             if (joyconf[6:4]==CURSOR)
                 kbdcol_out = kbdcol_out & {~db9joydown,~db9joyup,~db9joyright,~db9joyfire2,~db9joyfire_processed};
           end
@@ -154,30 +203,42 @@ module joystick_protocols (
           //Sinclair extendido,Z-X
           if (a[SINCLAIRADDRE]==1'b0) begin
             if (joyconf[6:4]==SINCLAIRP1)
-                    kbdcol_out = kbdcol_out & {2'b11, ~db9joyfire2, 2'b11};               
+               kbdcol_out = kbdcol_out & {2'b11, ~db9joyfire2, 2'b11};
             if (joyconf[6:4]==SINCLAIRP2)
                kbdcol_out = kbdcol_out & {3'b111, ~db9joyfire2, 1'b1};
+            if (joyconf[2:0]==SINCLAIRP1)
+               kbdcol_out = kbdcol_out & {2'b11, ~kbdjoyfire2, 2'b11};
+            if (joyconf[2:0]==SINCLAIRP2)
+               kbdcol_out = kbdcol_out & {3'b111, ~kbdjoyfire2, 1'b1};
           end
           //
           //Protocolo OPQASPACEM
           if (a[KMAPOP]==1'b0) begin
-            if (joyconf[6:4]==KMAPOPQA)    
+            if (joyconf[6:4]==KMAPOPQA)
                kbdcol_out = kbdcol_out & {3'b111,  ~db9joyleft, ~db9joyright};
-          end	
+            if (joyconf[2:0]==KMAPOPQA)
+               kbdcol_out = kbdcol_out & {3'b111,  ~kbdjoyleft, ~kbdjoyright};
+          end
           if (a[KMAPQ]==1'b0) begin
-            if (joyconf[6:4]==KMAPOPQA)    
+            if (joyconf[6:4]==KMAPOPQA)
                kbdcol_out = kbdcol_out & {4'b1111, ~db9joyup};
-          end	  	
+			if (joyconf[2:0]==KMAPOPQA)
+               kbdcol_out = kbdcol_out & {4'b1111, ~kbdjoyup};
+          end
           if (a[KMAPA]==1'b0) begin
-            if (joyconf[6:4]==KMAPOPQA)    
+            if (joyconf[6:4]==KMAPOPQA)
                kbdcol_out = kbdcol_out & {4'b1111,  ~db9joydown};
-          end	 
+            if (joyconf[2:0]==KMAPOPQA)
+               kbdcol_out = kbdcol_out & {4'b1111,  ~kbdjoydown};
+          end
           if (a[KMAPSPACEM]==1'b0) begin
-            if (joyconf[6:4]==KMAPOPQA)    
+            if (joyconf[6:4]==KMAPOPQA)
                kbdcol_out = kbdcol_out & {2'b11, ~db9joyfire2,  1'b1, ~db9joyfire_processed};
-          end	  
+            if (joyconf[2:0]==KMAPOPQA)
+               kbdcol_out = kbdcol_out & {2'b11, ~kbdjoyfire2,  1'b1, ~kbdjoyfire_processed};
+          end
           //
         end  // fin de lectura de I/O de teclado
-      end    // fin lectura genérica de I/O
+      end    // fin lectura genÃ©rica de I/O
     end
 endmodule

--- a/cores/spectrum/exp27/common/ps2_mouse_kempston.v
+++ b/cores/spectrum/exp27/common/ps2_mouse_kempston.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 17:14:21 2015-06-30 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -57,11 +57,11 @@ module ps2_mouse_kempston (
     wire nuevo_evento;
     wire [1:0] state_out;
     assign mousedata_dout = mousedata;
-    
-    wire kmouse_x_req    = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b1 && a[9]==1'b1 && a[10]==1'b0);
-    wire kmouse_y_req    = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b1 && a[9]==1'b1 && a[10]==1'b1);
-    wire kmouse_butt_req = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b0);
-    
+
+    wire kmouse_x_req    = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b1 && a[9]==1'b1 && a[10]==1'b0 && a[11]==1'b1);
+    wire kmouse_y_req    = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b1 && a[9]==1'b1 && a[10]==1'b1 && a[11]==1'b1);
+    wire kmouse_butt_req = (!iorq_n && !rd_n && a[7:0]==8'hDF && a[8]==1'b0 && a[9]==1'b1 && a[10]==1'b0 && a[11]==1'b1);
+
     always @* begin
       oe_kmouse = (kmouse_x_req | kmouse_y_req | kmouse_butt_req);
       case (1'b1)
@@ -71,7 +71,7 @@ module ps2_mouse_kempston (
         default         : kmouse_dout = 8'hFF;
       endcase
     end
-    
+
     /*
     | BSY | 0 | 0 | 0 | ERR | 0 | 0 | DATA_AVL |
     */
@@ -86,14 +86,14 @@ module ps2_mouse_kempston (
             mousestatus_dout[0] <= 1'b0;
             reading_mousestatus <= 1'b0;
         end
-    end        
+    end
 
     ps2_port lectura_de_raton (
         .clk(clk),
         .enable_rcv(~ps2busy),
         .kb_or_mouse(1'b1),
         .ps2clk_ext(clkps2),
-        
+
         .ps2data_ext(dataps2),
         .kb_interrupt(nuevo_evento),
         .scancode(mousedata),

--- a/cores/spectrum/exp27/common/zxuno.v
+++ b/cores/spectrum/exp27/common/zxuno.v
@@ -80,12 +80,16 @@ module zxuno (
   input wire joy1fire1,
   input wire joy1fire2,
 
+  // DB9 JOYSTICK 2
   input wire joy2up,
   input wire joy2down,
   input wire joy2left,
   input wire joy2right,
   input wire joy2fire1,
   input wire joy2fire2,
+
+  // DB9 splitter selector
+  output wire joy1fire3,
 
   // MOUSE
   inout wire mouseclk,
@@ -108,14 +112,14 @@ module zxuno (
   parameter FPGA_MODEL = 3'b000;
   parameter MASTERCLK  = 28000000;
 
-  // Señales del generador de enables de reloj
+  // SeÃ±ales del generador de enables de reloj
   wire CPUContention;
   wire [3:0] cpu_speed;
   wire clkcpu_enable;
   wire clk14en, clk7en, clk7en_n, clk35en, clk35en_n, clk175en;
   assign clk14en_tovga = clk14en;
 
-  // Señales de la CPU
+  // SeÃ±ales de la CPU
   wire mreq_n,iorq_n,rd_n,wr_n,int_n,m1_n,nmi_n,rfsh_n,busak_n;
   wire enable_nmi_n;
   wire [15:0] cpuaddr;
@@ -123,29 +127,29 @@ module zxuno (
   wire [7:0] cpudout;
   wire [7:0] ula_dout;
 
-  // Señales acceso RAM por parte de la ULA
+  // SeÃ±ales acceso RAM por parte de la ULA
   wire [13:0] vram_addr;
   wire [7:0] vram_dout;
 
-  // Señales acceso RAM por parte de la CPU
+  // SeÃ±ales acceso RAM por parte de la CPU
   wire [7:0] memory_dout;
   wire oe_romyram;
 
-  // Señales de acceso del AY por parte de la CPU
+  // SeÃ±ales de acceso del AY por parte de la CPU
   wire [7:0] ay_dout;
   wire bc1,bdir;
   wire oe_ay;
 
-  // Señales de acceso a registro de direcciones ZX-Uno
+  // SeÃ±ales de acceso a registro de direcciones ZX-Uno
   wire [7:0] zxuno_addr_to_cpu;  // al bus de datos de entrada del Z80
   wire [7:0] zxuno_addr;   // direccion de registro actual
   wire regaddr_changed;    // indica que se ha escrito un nuevo valor en el registro de direcciones
-  wire oe_zxunoaddr;     // el dato en el bus de entrada del Z80 es válido
+  wire oe_zxunoaddr;     // el dato en el bus de entrada del Z80 es vÃ¡lido
   wire zxuno_regrd;     // Acceso de lectura en el puerto de datos de ZX-Uno
   wire zxuno_regwr;     // Acceso de escritura en el puerto de datos del ZX-Uno
-  wire in_boot_mode;   // Vale 1 cuando el sistema está en modo boot (ejecutando la BIOS)
+  wire in_boot_mode;   // Vale 1 cuando el sistema estÃ¡ en modo boot (ejecutando la BIOS)
 
-  // Señales de acceso al módulo Flash SPI
+  // SeÃ±ales de acceso al mÃ³dulo Flash SPI
   wire [ 7:0] spi_dout;
   wire        oe_spi;
   wire        wait_spi_n;
@@ -185,7 +189,7 @@ module zxuno (
   wire f6_pressed        = user_fnt[5];   // Establecer marca de 'contador a 0'
   wire f7_pressed        = user_fnt[4];   // PLAY del PZX
   wire f8_pressed        = user_fnt[3];   // REWIND a la marca del 'contador a 0' puesta por usuario con F6
-  wire f8_ctrl_pressed   = user_fnt[13];   // REWIND al principio del PZX, o a la última posición marcada en el fichero
+  wire f8_ctrl_pressed   = user_fnt[13];   // REWIND al principio del PZX, o a la Ãºltima posiciÃ³n marcada en el fichero
   wire f9_pressed        = user_fnt[2];   // STOP del PZX
   wire f11_pressed       = user_fnt[1];   // WiFi
   wire f12_pressed       = user_fnt[0];   // Turbo-boost (28 MHz)
@@ -196,7 +200,7 @@ module zxuno (
   wire [7:0] joystick_dout;
   wire [4:0] kbdcol_to_ula;
 
-  // Configuración ULA
+  // ConfiguraciÃ³n ULA
   wire [1:0] timing_mode;
   wire issue2_keyboard;
   wire disable_contention;
@@ -300,22 +304,22 @@ module zxuno (
   wire write_data_pzx;
   wire ear = (pzx_playing == 1'b1)? pzx_output : ear_ext;
 
-  // Inyección de 0xFF directo al bus de datos cuando hay un acuse de recibo de interrupción
+  // InyecciÃ³n de 0xFF directo al bus de datos cuando hay un acuse de recibo de interrupciÃ³n
   wire oe_intack = (iorq_n == 1'b0 && m1_n == 1'b0);
 
   // Salidas de video de la ULA
   wire [2:0] rula,gula,bula;
   wire [8:0] hcnt, vcnt;
 
-  // Señales a conectar valores de depuracion
+  // SeÃ±ales a conectar valores de depuracion
   wire [15:0] v16_a, v16_b, v16_c, v16_d, v16_e, v16_f, v16_g, v16_h;
   wire [7:0] v8_a, v8_b, v8_c, v8_d, v8_e, v8_f, v8_g, v8_h;
 
-  // Asignación de dato para la CPU segun la decodificación de todos los dispositivos
+  // AsignaciÃ³n de dato para la CPU segun la decodificaciÃ³n de todos los dispositivos
   // conectados a ella.
   always @* begin
     case (1'b1)
-      oe_intack      : cpudin = 8'hFF;  // valor del bus de datos durante una interrupción enmascarable aceptada
+      oe_intack      : cpudin = 8'hFF;  // valor del bus de datos durante una interrupciÃ³n enmascarable aceptada
       oe_zxunoaddr   : cpudin = zxuno_addr_to_cpu;
       oe_spi         : cpudin = spi_dout;
       oe_scancode    : cpudin = scancode_dout;
@@ -495,7 +499,7 @@ module zxuno (
 
   new_memory bootrom_rom_y_ram (
   // Relojes y reset
-    .clk(sysclk),   // Reloj para registros de configuración
+    .clk(sysclk),   // Reloj para registros de configuraciÃ³n
     .mrst_n(mrst_n & power_on_reset_n),
     .rst_n(rst_n & power_on_reset_n),
 
@@ -512,7 +516,7 @@ module zxuno (
     .rfsh_n             (rfsh_n         ),
     .busak_n            (busak_n        ),
     .enable_nmi_n       (enable_nmi_n   ),
-    .page_configrom_active(page_configrom_active),              // Para habilitar la ROM de ayuda y configuración
+    .page_configrom_active(page_configrom_active),              // Para habilitar la ROM de ayuda y configuraciÃ³n
 
 // Interface con la ULA
     .vramaddr           (vram_addr      ),
@@ -560,9 +564,9 @@ module zxuno (
     .dataps2            (dataps2        ),
     .rows               (kbdrow         ),
     .cols               (kbdcol         ),
-    .joy                (kbd_joy        ),                      // Implementación joystick en teclado numerico
+    .joy                (kbd_joy        ),                      // ImplementaciÃ³n joystick en teclado numerico
     .rst_out_n          (rst_n          ),                      // esto son salidas, no entradas
-    .nmi_out_n          (nmi_n          ),                      // Señales de reset y NMI
+    .nmi_out_n          (nmi_n          ),                      // SeÃ±ales de reset y NMI
     .mrst_out_n         (mrst_n         ),                      // generadas por pulsaciones especiales del teclado
     .user_fnt           (user_fnt       ),                      // funciones de usuario
     .video_output_change(video_output_change),
@@ -596,7 +600,8 @@ module zxuno (
   //-- actual joystick and keyboard signals
     .kbdjoy_in          (kbd_joy        ),
     .db9joy1_in({joy1fire2, joy1fire1, joy1up, joy1down, joy1left, joy1right}),
-    .db9joy2_in({joy2fire2, joy2fire1, joy2up, joy2down, joy2left, joy2right}),
+	.db9joy2_in({joy2fire2, joy2fire1, joy2up, joy2down, joy2left, joy2right}),
+	.joy1fire3(joy1fire3),
     .kbdcol_in(kbdcol),
     .kbdcol_out(kbdcol_to_ula),
     .vertical_retrace_int_n(int_n) // this is used as base clock for autofire
@@ -930,12 +935,13 @@ module zxuno (
 
 `ifdef UART_ESP8266_OPTION
   // UART para el ESP8266
-  
+
 	`ifdef F11_ESP8266_FEATURE
 		assign wifi_switcher = f11_pressed;
 	`else
-		assign wifi_switcher = 1'b0;		
-		
+		assign wifi_switcher = 1'b0;
+	`endif
+
   zxunouart #(.CLK(MASTERCLK)) uart_esp8266 (
     .clk                (sysclk         ),
     .zxuno_addr         (zxuno_addr     ),

--- a/cores/spectrum/exp27/zxuno_v4/tld_zxuno_v4.v
+++ b/cores/spectrum/exp27/zxuno_v4/tld_zxuno_v4.v
@@ -1,7 +1,7 @@
 `timescale 1ns / 1ns
 `default_nettype none
 
-//    This file is part of the ZXUNO Spectrum core. 
+//    This file is part of the ZXUNO Spectrum core.
 //    Creation date is 02:28:18 2014-02-06 by Miguel Angel Rodriguez Jodar
 //    (c)2014-2020 ZXUNO association.
 //    ZXUNO official repository: http://svn.zxuno.com/svn/zxuno
@@ -42,7 +42,7 @@ module tld_zxuno_v4 (
    output wire midi_out,
    input wire clkbd,
    input wire wsbd,
-   input wire dabd,    
+   input wire dabd,
 
    output wire uart_tx,
    input wire uart_rx,
@@ -51,22 +51,22 @@ module tld_zxuno_v4 (
 
    output wire stdn,
    output wire stdnb,
-   
+
    output wire [20:0] sram_addr,
    inout wire [7:0] sram_data,
    output wire sram_we_n,
-   
+
    output wire flash_cs_n,
    output wire flash_clk,
    output wire flash_mosi,
    input wire flash_miso,
-   
-   output wire sd_cs_n,    
-   output wire sd_clk,     
-   output wire sd_mosi,    
+
+   output wire sd_cs_n,
+   output wire sd_clk,
+   output wire sd_mosi,
    input wire sd_miso,
-   output wire testled,   // nos servir· como testigo de uso de la SPI
-	
+   output wire testled,   // nos servir√° como testigo de uso de la SPI
+
    input wire joyup,
    input wire joydown,
    input wire joyleft,
@@ -75,17 +75,17 @@ module tld_zxuno_v4 (
    input wire joybtn2,
    output wire joybtn3
    );
-	
+
 	wire [2:0] ri_monochrome, gi_monochrome, bi_monochrome;
 	wire [1:0] monochrome_switcher;
-	wire wifi_switcher;	
+	wire wifi_switcher;
 
 `include "../common/config.vh"
 
    wire sysclk, mcolorclk;
    wire disable_genclk;
-   wire [2:0] pll_frequency_option;	
-   
+   wire [2:0] pll_frequency_option;
+
    clock_generator relojes_maestros
    (// Clock in ports
     .CLK_IN1            (clk50mhz),
@@ -100,10 +100,10 @@ module tld_zxuno_v4 (
    wire vga_enable, scanlines_enable;
    wire clk14en_tovga;
    wire clkcolor4x, ad724_enable_gencolorclk;
-	
+
    zxuno #(.FPGA_MODEL(3'b001), .MASTERCLK(28000000)) la_maquina (
     .sysclk(sysclk),
-    .power_on_reset_n(1'b1),  // sÛlo para simulaciÛn. Para implementacion, dejar a 1
+    .power_on_reset_n(1'b1),  // s√≥lo para simulaci√≥n. Para implementacion, dejar a 1
     .r(ri),
     .g(gi),
     .b(bi),
@@ -111,18 +111,18 @@ module tld_zxuno_v4 (
     .vsync(vsync_pal),
     .csync(csync_pal),
 	 .monochrome_switcher(monochrome_switcher),
-	 .wifi_switcher(wifi_switcher),	 
+	 .wifi_switcher(wifi_switcher),
     .clkps2(clkps2),
     .dataps2(dataps2),
     .ear_ext(~ear),  // negada porque el hardware tiene un transistor inversor
     .audio_out_left(audio_out_left),
     .audio_out_right(audio_out_right),
-    
+
     .midi_out(midi_out),
     .clkbd(clkbd),
     .wsbd(wsbd),
     .dabd(dabd),
-    
+
     .uart_tx(uart_tx),
     .uart_rx(uart_rx),
     .uart_rts(uart_rts),
@@ -130,39 +130,41 @@ module tld_zxuno_v4 (
     .sram_addr(sram_addr),
     .sram_data(sram_data),
     .sram_we_n(sram_we_n),
-    
+
     .flash_cs_n(flash_cs_n),
     .flash_clk(flash_clk),
-    .flash_di(flash_mosi), 
+    .flash_di(flash_mosi),
     .flash_do(flash_miso),
-    
+
     .sd_cs_n(sd_cs_n),
     .sd_clk(sd_clk),
     .sd_mosi(sd_mosi),
     .sd_miso(sd_miso),
-    
+
     .joy1up(joyup),
     .joy1down(joydown),
     .joy1left(joyleft),
     .joy1right(joyright),
     .joy1fire1(joyfire),
-    .joy1fire2(joybtn2),    
-	 
+    .joy1fire2(joybtn2),
+
     .joy2up(1'b1),
     .joy2down(1'b1),
     .joy2left(1'b1),
     .joy2right(1'b1),
     .joy2fire1(1'b1),
-    .joy2fire2(1'b1),    
+    .joy2fire2(1'b1),
+
+    .joy1fire3(joybtn3),
 
     .mouseclk(mouseclk),
     .mousedata(mousedata),
-    
+
     .clk14en_tovga(clk14en_tovga),
     .vga_enable(vga_enable),
     .scanlines_enable(scanlines_enable),
     .freq_option(pll_frequency_option),
-        
+
     .ad724_xtal(stdnb),
     .ad724_mode(stdn),
     .ad724_enable_gencolorclk(ad724_enable_gencolorclk)
@@ -187,7 +189,7 @@ module tld_zxuno_v4 (
     .bi(bi),
     .ro(ri_monochrome),
     .go(gi_monochrome),
-    .bo(bi_monochrome)  
+    .bo(bi_monochrome)
   );
  `else
    assign ri_monochrome = ri;
@@ -212,16 +214,15 @@ module tld_zxuno_v4 (
 		.bo(b),
 		.hsync(hsync),
 		.vsync(vsync)
-   );	 
-       
+   );
+
    assign testled = (!flash_cs_n || !sd_cs_n);
-   assign joybtn3 = 0;
-	
+
 	`ifdef UART_ESP8266_OPTION
 		assign uart_reset = (!wifi_switcher) ? 1'b0 : 1'bz;
 	`else
 	   assign uart_reset = 1'b0;
 	`endif
-	
-	
+
+
 endmodule


### PR DESCRIPTION
Se añade soporte opcional para joystick splitter. El segundo joystick se combina con el keypad joystick y segundo db9 si existe.

Se modifica decodificación del ratón kempston para que funcione el Tiro al pichón de Microhobby. Ahora se decodifican los 12 bits bajos de los puertos kempston mouse (antes se decodificaban algunos bits menos).

Se añade el puerto DFh como lectura del joystick kempston.

Se añade que el segundo botón de un joystick funcione en modo Sinclair y Cursor.

